### PR TITLE
Adds links plugin that provides global hash with links. Can reference docs and images.

### DIFF
--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -119,4 +119,4 @@ defaults:
     scope:
       path: "_docs/artik-ide-plugin"
     values:
-      categories: [ "docs" , "artik" ]
+      categories: [ "docs" , "artik" ] 

--- a/src/main/_config.yml
+++ b/src/main/_config.yml
@@ -104,7 +104,7 @@ defaults:
     scope:
       path: "_docs/openshift-plugin"
     values:
-      category: [ "docs" , "openshift" ]
+      categories: [ "docs" , "openshift" ]
   -
     scope:
       path: "_docs/chedir-portable-workspaces"

--- a/src/main/_plugins/links.rb
+++ b/src/main/_plugins/links.rb
@@ -1,0 +1,82 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2016 Codenvy, S.A.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Codenvy, S.A. - initial API and implementation
+#
+
+module Reading
+  class Generator < Jekyll::Generator
+    def generate(site)
+      begin
+          docs = site.docs_to_write
+          entries = {}
+          collections = {}
+          
+          site.collections["docs"].filtered_entries.each do |entry|
+            page = ""
+            site.config["defaults"].each do |default|
+                scope = default["scope"]
+                path = scope["path"]
+                full_path = "_docs/" + entry
+                if full_path.include? path
+                    value = default["values"]
+                    categories = value["categories"]
+                    categories.each do |category|
+                        page=page+"/"+category
+                    end
+                    page=page+"/"
+                end
+                if full_path.include? "assets/"
+                    image_name = entry.split('/').pop
+                    collections[image_name]="/docs/"+entry
+                end
+            end
+            
+            entries[entry]=page 
+          end
+          
+          site.config["collections"].each do |collection|
+            if collection[0] != "posts"
+              collections=collections.merge(get_col(site,collection[0],entries))
+            end
+          end     
+          #puts collections
+          site.config["links"] = collections
+      rescue 
+          red = "\033[0;31m"
+          puts red + "Jekyll> There is an error in the ruby plugin file _plugins/links.rb." 
+          puts red + "Jekyll> Check collection files such ass 'docs.yml' and 'tutorials.yml' under _data/ folder are formatted correctly."
+          puts ""
+          raise
+      end
+    end
+    def get_col(site,col_name, entries)
+        collections = {}
+        hash1 = site.data
+        hash1.each do |hash2|
+            hash3 = hash1[col_name]
+            hash3.each do |hash4|
+                
+                files = hash4[col_name]                
+                files.each do |file|
+                    parse = file.split('-')
+                    parse.shift
+                    parse = parse.join('-')
+                    entries.keys.any? {|k| 
+                        if k.include? file 
+                            collections[file]=entries[k]+parse+"/index.html"
+                        end
+                        }
+                end
+            end
+        end
+        return collections
+    end
+  end
+end


### PR DESCRIPTION
# Linking to Docs and Images
Because the docs are generated into static HTML linking to docs and images is a bit unusual. We provide a custom plugin [_plugins/links.rb](_plugins/links.rb) to create links.
- Link to a Che docs page "_docs/workspace-administration/ws-agents.md": `[workspace agents]({{base+sites.links["ws-agents"]}})`
  - Link definition `[<link description shown in html>]({{base+sites.links["<file base name>"]}}#<section name>)`
  - `sites.links["<file base name>"]` is a global hash value created by links plugin [_plugins/links.rb](_plugins/links.rb) before html generation.
  - Links plugin uses the following variables in [_config.yml](_config.yml) file:
    - Each `defaults.value.categories` used to create same permalink used in markdown file.
    - Each `collections` used to find file paths for each markdown file specified in [_data](_data) folder.
  - Section of markdown files can be optionally linked by adding `#<section name>` at end.
    - The \<section name\> come from taking section title and making all lower case and replace space with `-`. Ex. `# Creating New Agent` would be `#creating-new-agents`.
- Link to image `/docs/assets/imgs/quick-documentation.png`: `![quick-documentation.png]({{base+sites.links["quick-documentation.png"]}})`
