### PR TITLE
Img border and inline code styles

### DIFF
--- a/src/main/_sass/_style.scss
+++ b/src/main/_sass/_style.scss
@@ -533,7 +533,6 @@ aside {
 
     img {
       border: 1px solid rgba(0,0,0,0.06);
-      color: #000;
       width: 80%;
       display: block;
       margin-left: auto;
@@ -735,7 +734,7 @@ li> pre,
 h5 > code,
 .note > code {
   background-color: rgba(0,0,0,0.08);
-  color: #fff;
+  color: #000;
   max-width: 100%;
   overflow-x: auto;
   vertical-align: middle;

--- a/src/main/_sass/_style.scss
+++ b/src/main/_sass/_style.scss
@@ -523,7 +523,10 @@ aside {
 
 /* Documentation */
 
-.docs {
+.docs,
+.tutorials,
+.openshift,
+.artik {
 
   article {
     min-height: 800px;

--- a/src/main/_sass/_style.scss
+++ b/src/main/_sass/_style.scss
@@ -532,6 +532,8 @@ aside {
     min-height: 800px;
 
     img {
+      border: 1px solid rgba(0,0,0,0.06);
+      color: #000;
       width: 80%;
       display: block;
       margin-left: auto;
@@ -732,7 +734,7 @@ li > code,
 li> pre,
 h5 > code,
 .note > code {
-  background-color: #444;
+  background-color: rgba(0,0,0,0.08);
   color: #fff;
   max-width: 100%;
   overflow-x: auto;


### PR DESCRIPTION
Added image styling to all layouts. Was only on docs layout.

Adds a light border to images. Images with white background seem to merge into background. Border adds clarity to white background images but doesn't show up on darker which is ok for me.

Inline code is too detracting with dark background. Went back to github style but darkened it from .04 to .08 which makes it easier for me to see and does not distract as much as dark background. Code blocks will remain dark as they are only inline is effected.

Before:
![image](https://cloud.githubusercontent.com/assets/20580888/21596426/ad5ab8da-d100-11e6-83a4-c3a5537571a5.png)

After
![image](https://cloud.githubusercontent.com/assets/20580888/21596514/cb87d8f0-d101-11e6-8fc5-a977ae16ce88.png)


Signed-off-by: James Drummond jdrummond@codenvy.com