### PR TITLE
bower and gulp are installed by npm so no need to install them globally

### DIFF
--- a/src/main/_docs/write-che-ide-plugins/plugins-setup-che-workspace.md
+++ b/src/main/_docs/write-che-ide-plugins/plugins-setup-che-workspace.md
@@ -31,13 +31,8 @@ To build the user dashboard submodule, you will need npm, bower, gulp, and pytho
 - Python `v2.7.x` (`v3.x.x` is currently not supported)
 - Node.js `v4.x.x` (`v5.x.x` / `v6.x.x` are currently not supported)
 - npm
-- Bower
-- gulp
 
-Installation instructions for Node.js and npm can be found on the following [link](https://docs.npmjs.com/getting-started/installing-node). Bower and gulp are CLI utilities which are installed via npm:
-```shell  
-$ npm install --global bower gulp
-```
+Installation instructions for Node.js and npm can be found on the following [link](https://docs.npmjs.com/getting-started/installing-node). 
 
 # Developers on Windows  
 


### PR DESCRIPTION
It's done with https://github.com/eclipse/che/pull/3828